### PR TITLE
Add cspell command

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Run tests on the `web/modules/custom` directory:
 - `ddev phpcbf` Fix phpcs findings.
 - `ddev eslint` Run [ESLint](https://github.com/eslint/eslint) on JavaScript files.
 - `ddev stylelint` Run [Stylelint](https://github.com/stylelint/stylelint) on CSS files.
-
+- `ddev cspell` Run [Cspell](https://cspell.org/).
 
 ## Codebase layout
 

--- a/commands/web/cspell
+++ b/commands/web/cspell
@@ -1,0 +1,43 @@
+#!/bin/bash
+
+#ddev-generated
+## Command provided by https://github.com/ddev/ddev-drupal-contrib
+## Description: Run cspell inside the web container
+## Usage: cspell [flags] [args]
+## Example: "ddev cspell" or "ddev cspell --version"
+## ProjectTypes: drupal,drupal8,drupal9,drupal10
+## ExecRaw: true
+
+
+CSPELL="$DDEV_COMPOSER_ROOT/$DDEV_DOCROOT/core/node_modules/.bin/cspell"
+if $CSPELL --version >/dev/null ; then
+
+  # Create required cspell files and note whether they're temporary, for
+  # clean-up later.
+  TMP_PROJECT_WORDS=$(test -e .cspell-project-words.txt ; echo $?)
+  TMP_CSPELL=$(test -e .cspell.json; echo $?)
+  touch .cspell-project-words.txt
+  test -e .cspell.json || curl -OLs https://git.drupalcode.org/project/gitlab_templates/-/raw/default-ref/assets/.cspell.json
+
+  # Augment .cspell.json for Drupal so it can be restored to its pristine
+  # state after spellcheck. Passing '.ddev' to the prepare script stores
+  # output to .cspell.json.ddev to avoid overwriting the original file.
+  curl -OLs https://git.drupalcode.org/project/gitlab_templates/-/raw/default-ref/scripts/prepare-cspell.php
+  export _WEB_ROOT="$DDEV_COMPOSER_ROOT/$DDEV_DOCROOT"
+  export CI_PROJECT_NAME="$DDEV_SITENAME"
+  touch .cspell.json.ddev
+  php prepare-cspell.php .ddev
+  rm prepare-cspell.php
+
+  # The cspell `-c` argument requires the filename to end in json.
+  mv -f .cspell.json.ddev .cspell.ddev.json
+  $CSPELL -c .cspell.ddev.json --show-suggestions --show-context --no-progress $DDEV_DOCROOT/modules/custom/*/** "$@"
+
+  # Clean-up temporary cspell files.
+  rm .cspell.ddev.json
+  [ "$TMP_PROJECT_WORDS" == "1" ] && rm .cspell-project-words.txt
+  [ "$TMP_CSPELL" == "1" ] && rm .cspell.json
+else
+  echo "cspell is not available. You may need to 'ddev yarn --cwd $DDEV_DOCROOT/core install'"
+  exit 1
+fi

--- a/commands/web/cspell
+++ b/commands/web/cspell
@@ -23,15 +23,16 @@ if $CSPELL --version >/dev/null ; then
   # state after spellcheck. Passing '.ddev' to the prepare script stores
   # output to .cspell.json.ddev to avoid overwriting the original file.
   curl -OLs https://git.drupalcode.org/project/gitlab_templates/-/raw/default-ref/scripts/prepare-cspell.php
-  export _WEB_ROOT="$DDEV_COMPOSER_ROOT/$DDEV_DOCROOT"
   export CI_PROJECT_NAME="$DDEV_SITENAME"
+  export _WEB_ROOT="$DDEV_COMPOSER_ROOT/$DDEV_DOCROOT"
+  export _CSPELL_IGNORE_PATHS="$DDEV_DOCROOT,.ddev"
   touch .cspell.json.ddev
   php prepare-cspell.php .ddev
   rm prepare-cspell.php
 
   # The cspell `-c` argument requires the filename to end in json.
   mv -f .cspell.json.ddev .cspell.ddev.json
-  $CSPELL -c .cspell.ddev.json --show-suggestions --show-context --no-progress $DDEV_DOCROOT/modules/custom/*/** "$@"
+  $CSPELL -c .cspell.ddev.json --show-suggestions --show-context --no-progress ** "$@"
 
   # Clean-up temporary cspell files.
   rm .cspell.ddev.json


### PR DESCRIPTION
## The Issue

Let users run [cspell](https://cspell.org/) in the same way that it is run on Drupal's GitLabCI. See [gitlab_template docs](https://project.pages.drupalcode.org/gitlab_templates/jobs/cspell/).

## How This PR Solves The Issue

The `ddev cspell` command will detect existence of custom `.cspell-project-words.txt` and `.cspell.json` in your project folder, and generate fallbacks if the project doesn't have or need customizations, so that cspell command (provided by Drupal core yarn install) will not break. The fallback files are then automatically cleaned up after execution.  

## Manual Testing Instructions

* (Optional) Run `ddev cspell` for a project that needs `.cspell-project-words.txt` and confirm files are checked and execution succeeds.
* Run `ddev cspell` for a project that needs no `.cspell-project-words.txt` and confirm files are checked and execution succeeds.
* Add a `random-test-filename.yml` with nonsense word "asdfasdfasdf", and confirm the new file is checked and execution fails.
* Add `.cspell-project-words.txt` with nonsense word "asdfasdfasdf", and confirm the new file is checked and execution passes.



## Automated Testing Overview

Requires no automated testing.

## Related Issue Link(s)

N/a

## Release/Deployment Notes

N/a