### PR TITLE
fix: stylelint to use the same approach as eslint

### DIFF
--- a/commands/web/stylelint
+++ b/commands/web/stylelint
@@ -7,8 +7,10 @@
 ## Example: "ddev stylelint"
 ## ExecRaw: true
 
-if yarn --cwd "$DDEV_DOCROOT/core" stylelint --version >/dev/null ; then
-  yarn --color --cwd "$DDEV_DOCROOT/core" --config ./.stylelintrc.json stylelint ../modules/custom/**/*.css "$@"
+if $DDEV_DOCROOT/core/node_modules/.bin/stylelint --version >/dev/null ; then
+  # Change directory to the project root folder
+  cd "$DDEV_DOCROOT/modules/custom/${DDEV_SITENAME//-/_}" || exit
+  "$DDEV_COMPOSER_ROOT/$DDEV_DOCROOT/core/node_modules/.bin/stylelint" --color --config "$DDEV_COMPOSER_ROOT/$DDEV_DOCROOT/core/.stylelintrc.json" "./**/*.css" "$@"
 else
   echo "stylelint is not available. You may need to 'ddev yarn --cwd $DDEV_DOCROOT/core install'"
   exit 1


### PR DESCRIPTION
Styleint wasn't working for me on a contrib with d11.

I tried to fix this using the similar approach as the current eslint command, which I'd hope it shsuld work for other core versions too.