### PR TITLE
Minor README edits

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,14 +17,13 @@ DDEV integration for developing Drupal contrib projects. As a general philosophy
 
 ```sh
 # Configure DDEV for Drupal, or use interactive mode.
-ddev config --project-type=drupal --docroot=web --php-version=8.3 --corepack-enable
+ddev config --project-type=drupal11 --docroot=web
 ddev add-on get ddev/ddev-drupal-contrib
 ddev start
 ddev poser
 ddev symlink-project
 # Detect expected Drupal and PHP versions.
 ddev config --update
-ddev restart
 ```
 
 ## Update


### PR DESCRIPTION

## The Issue

* We don't really suggest the `drupal` project type any more. It was too complicated for people. Still supported but not mentioned. Using `drupal11` here.
* There's no need these days to add `--php-version=8.3 --corepack-enable`. Default PHP version is 8.4 (as per drupal11 support) and `corepack-enable` is automatic for drupal11. However, if you think the default version of PHP (8.4) is not a good idea, this could be shown as `--php-version=8.4` to show people explicitly how to change it.

## How This PR Solves The Issue

Minor README updates

