### PR TITLE
Add `COMPOSER_NO_SECURITY_BLOCKING=1` to tests

### DIFF
--- a/commands/web/poser
+++ b/commands/web/poser
@@ -12,7 +12,7 @@ set -eu -o pipefail
 
 export COMPOSER=composer.contrib.json
 .ddev/commands/web/expand-composer-json
-composer install "$@"
+COMPOSER_NO_SECURITY_BLOCKING=1 composer install "$@"
 # The -f flag suppresses errors if lock file does not exist.
 rm -f composer.contrib.json composer.contrib.lock
 touch $DDEV_DOCROOT/core/.env

--- a/commands/web/poser
+++ b/commands/web/poser
@@ -12,7 +12,7 @@ set -eu -o pipefail
 
 export COMPOSER=composer.contrib.json
 .ddev/commands/web/expand-composer-json
-COMPOSER_NO_SECURITY_BLOCKING=1 composer install "$@"
+composer install "$@"
 # The -f flag suppresses errors if lock file does not exist.
 rm -f composer.contrib.json composer.contrib.lock
 touch $DDEV_DOCROOT/core/.env

--- a/tests/_common.bash
+++ b/tests/_common.bash
@@ -11,7 +11,7 @@ _common_setup() {
   ddev delete -Oy ${PROJNAME} >/dev/null 2>&1 || true
   cp -R ${DIR}/tests/testdata/test_drupal_contrib/* ${TESTDIR}
   cd ${TESTDIR}
-  ddev config --project-name=${PROJNAME} --project-type=drupal --docroot=web --php-version=8.3 --corepack-enable
+  ddev config --project-name=${PROJNAME} --project-type=drupal --docroot=web --php-version=8.3 --corepack-enable --web-environment-add=COMPOSER_NO_SECURITY_BLOCKING=1
   if [ -n "$TEST_DRUPAL_CORE" ] && [ "$TEST_DRUPAL_CORE" != "default" ]; then
     ddev dotenv set .ddev/.env.web --drupal-core "^${TEST_DRUPAL_CORE}"
   fi


### PR DESCRIPTION
## The Issue

https://github.com/ddev/ddev-drupal-contrib/actions/runs/26154402586/job/76957222933

```
# Your requirements could not be resolved to an installable set of packages.
#
#   Problem 1
#     - Root composer.json requires drupal/core-recommended ^11 -> satisfiable by drupal/core-recommended[11.0.8, ..., 11.x-dev].
#     - drupal/core-recommended 11.0.10 requires drupal/core 11.0.10 -> found drupal/core[11.0.10] but these were not loaded, because they are affected by security advisories ("SA-CORE-2025-001", "SA-CORE-2025-002", "SA-CORE-2025-003", "SA-CORE-2025-004", "SA-CORE-2025-007", "SA-CORE-2025-008", "SA-CORE-2025-005", "SA-CORE-2025-006", "SA-CORE-2026-001", "SA-CORE-2026-002", "PKSA-d8tb-wwz2-ctxk", "PKSA-dh1f-zjm5-qg8y", "PKSA-bn52-vyzy-rmnm", "PKSA-xj83-g6g8-41vf", "PKSA-s1zc-gcfk-ddw5", "PKSA-ctyc-dmct-npkz", "PKSA-42zc-x5ss-z64p", "PKSA-s6zc-mws4-ngh4"). Go to 
```

## How This PR Solves The Issue

It's annoying to see tests failing when there are new security advisories.

Composer has `COMPOSER_NO_SECURITY_BLOCKING=1` env variable.

## Manual Testing Instructions

```bash
ddev add-on get ddev/ddev-drupal-contrib --pr 171
ddev restart
```

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->
